### PR TITLE
Improve popup UI spacing and layout

### DIFF
--- a/topaz-extension-main/popup/popup.css
+++ b/topaz-extension-main/popup/popup.css
@@ -8,20 +8,24 @@
 .preview-bar {
     width: 100%;
     padding: 0 var(--space-sm);
+    display: flex;
+    justify-content: center;
 }
 
 .preview-bar .tab-button {
-    width: 100%;
+    width: auto;
+    min-width: 200px;
     background: var(--bg-primary);
     border: 1px solid var(--border-primary);
     color: var(--text-primary);
-    height: var(--button-height-md);
+    height: var(--button-height-sm);
     border-radius: var(--radius-md);
-    font-size: var(--font-size-sm);
+    font-size: var(--font-size-xs);
     font-weight: var(--font-weight-semibold);
     letter-spacing: 0.5px;
     text-transform: uppercase;
     transition: var(--transition-all);
+    padding: 0 var(--space-lg);
 }
 
 .preview-bar .tab-button.active {
@@ -166,8 +170,8 @@
     --transition-opacity: opacity 0.3s ease;
     
     /* Layout Dimensions */
-    --popup-width: 340px;
-    --popup-height: 760px;
+    --popup-width: 300px;
+    --popup-height: 570px;
     --button-height-sm: 20px;
     --button-height-md: 26px;
     --button-height-lg: 32px;
@@ -367,7 +371,7 @@ body {
     flex-direction: column;
     align-items: center;
     gap: var(--space-sm);
-    padding-bottom: var(--space-sm);
+    padding-bottom: var(--space-xs);
     margin: 0 var(--space-md);
 }
 
@@ -450,11 +454,11 @@ body {
     background: var(--bg-button);
     border: 2px solid var(--bg-button-hover);
     border-radius: var(--radius-md);
-    padding: var(--space-3xl) var(--space-4xl);
+    padding: var(--space-2xl) var(--space-3xl);
     cursor: pointer;
     transition: var(--transition-normal);
     font-family: inherit;
-    font-size: var(--font-size-xl);
+    font-size: var(--font-size-lg);
     font-weight: var(--font-weight-semibold);
     width: 100%;
     outline: none;
@@ -467,13 +471,13 @@ body {
     display: flex;
     flex-direction: row;
     align-items: center;
-    gap: var(--space-3xl);
+    gap: var(--space-2xl);
     width: 100%;
 }
 
 .toggle-button .logo {
-    width: 56px;
-    height: 56px;
+    width: 48px;
+    height: 48px;
     transition: filter var(--transition-normal);
     flex-shrink: 0;
 }
@@ -488,14 +492,14 @@ body {
 }
 
 .title {
-    font-size: var(--font-size-3xl);
+    font-size: var(--font-size-2xl);
     font-weight: var(--font-weight-bold);
     line-height: var(--line-height-tight);
     letter-spacing: -0.5px;
 }
 
 .status {
-    font-size: var(--font-size-md);
+    font-size: var(--font-size-sm);
     font-weight: var(--font-weight-medium);
     opacity: 0.8;
     text-transform: uppercase;
@@ -548,9 +552,9 @@ body {
     display: block;
     background: var(--bg-secondary);
     border-radius: var(--radius-md);
-    padding: var(--space-lg);
+    padding: var(--space-md);
     flex: 0 0 auto;
-    max-height: 120px;
+    max-height: 100px;
     margin: 0 var(--space-md);
     overflow: hidden;
 }
@@ -562,7 +566,7 @@ body {
 }
 
 .profiles-header {
-    margin-bottom: var(--space-lg);
+    margin-bottom: var(--space-md);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -570,7 +574,7 @@ body {
 }
 
 .profiles-header h3 {
-    font-size: var(--font-size-xl);
+    font-size: var(--font-size-lg);
     font-weight: var(--font-weight-semibold);
     color: var(--text-primary);
     margin: 0;
@@ -611,7 +615,7 @@ body {
 .profiles-grid {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--space-md);
+    gap: var(--space-sm);
     flex: 1;
     overflow-y: auto;
     padding: var(--space-xs) 0;
@@ -622,9 +626,9 @@ body {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: var(--profile-chip-padding);
+    padding: 6px 12px;
     border-radius: var(--space-3xl);
-    font-size: var(--font-size-lg);
+    font-size: var(--font-size-base);
     font-weight: var(--font-weight-semibold);
     cursor: pointer;
     transition: var(--transition-all);
@@ -632,7 +636,7 @@ body {
     text-transform: lowercase;
     letter-spacing: 0.3px;
     outline: none;
-    min-width: 80px;
+    min-width: 70px;
 }
 
 .profile-chip:hover {
@@ -709,6 +713,9 @@ body {
 /* Default profile styles - same as regular profiles */
 .profile-chip.default-profile {
     /* No special styling - use default profile-chip styles */
+    background: var(--bg-modal);
+    color: var(--text-secondary);
+    border: 1px solid var(--border-secondary);
 }
 
 /* Default profile in edit mode - darkened and disabled appearance but still clickable */
@@ -1740,11 +1747,11 @@ body {
 /* Stats section */
 .stats-section {
     display: block;
-    margin-top: auto;
+    margin-top: -10px;
     margin-left: var(--space-md);
     margin-right: var(--space-md);
     flex-shrink: 0;
-    margin-bottom: var(--space-sm);
+    margin-bottom: 0
 }
 
 .stats-header h3 {
@@ -1774,7 +1781,7 @@ body {
 }
 
 .stat-number {
-    font-size: var(--font-size-4xl);
+    font-size: var(--font-size-3xl);
     font-weight: var(--font-weight-bold);
     color: var(--color-primary);
     line-height: var(--line-height-tight);
@@ -1782,7 +1789,7 @@ body {
 }
 
 .stat-label {
-    font-size: var(--font-size-base);
+    font-size: var(--font-size-sm);
     color: var(--text-primary);
     font-weight: var(--font-weight-medium);
 }
@@ -1971,6 +1978,7 @@ body {
 .blocked-item-text {
     display: -webkit-box;
     -webkit-line-clamp: 2;
+    line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -2795,9 +2803,9 @@ body {
     display: block;
     background: #252525;
     border-radius: 6px;
-    padding: 12px;
-    flex: 1;
-    min-height: 0;
+    padding: 6px;
+    flex: 0 0 auto;
+    height: 180px;
     margin: 0 6px;
 }
 
@@ -2916,9 +2924,9 @@ body {
     background: transparent;
     border: none;
     color: #999;
-    padding: 6px 8px;
+    padding: 4px 6px;
     border-radius: 4px;
-    font-size: 11px;
+    font-size: 10px;
     font-weight: 600;
     cursor: pointer;
     transition: all 0.3s ease;
@@ -2974,7 +2982,7 @@ body {
     min-height: 60px;
     flex: 1;
     overflow-y: auto;
-    padding: 8px;
+    padding: 5px;
     background: #1a1a1a;
     border-radius: 6px;
     border: 1px solid #333;
@@ -3000,9 +3008,9 @@ body {
     align-items: center;
     background: #333;
     color: white;
-    padding: 6px 12px;
-    border-radius: 14px;
-    font-size: 11px;
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 10px;
     font-weight: 600;
     transition: all 0.3s ease;
     cursor: pointer;
@@ -3026,7 +3034,7 @@ body {
 
 .simple-chip-system .add-item-container {
     display: flex;
-    gap: 6px;
+    gap: 4px;
     align-items: center;
     transition: opacity 0.3s ease;
 }
@@ -3055,23 +3063,23 @@ body {
     background: #1a1a1a;
     border: 1px solid #333;
     border-radius: 6px;
-    padding: 6px 36px 6px 8px;
+    padding: 4px 24px 4px 8px;
     color: white;
-    font-size: 11px;
+    font-size: 10px;
     outline: none;
     transition: all 0.3s ease;
-    height: 26px;
+    height: 24px;
     box-sizing: border-box;
 }
 
 .simple-chip-system .send-button {
     position: absolute;
-    right: 2px;
+    right: 3px;
     background: none;
     border: none;
     color: #999;
-    width: 22px;
-    height: 22px;
+    width: 18px;
+    height: 18px;
     border-radius: 4px;
     cursor: pointer;
     transition: all 0.3s ease;
@@ -3118,9 +3126,9 @@ body {
     background: var(--bg-tertiary);
     border: 1px solid var(--border-secondary);
     color: var(--text-muted);
-    width: var(--button-height-md);
-    height: var(--button-height-md);
-    border-radius: var(--radius-md);
+    width: 20px;
+    height: 20px;
+    border-radius: var(--radius-sm);
     cursor: pointer;
     transition: var(--transition-normal);
     display: flex;
@@ -3150,9 +3158,9 @@ body {
     background: var(--bg-tertiary);
     border: 1px solid var(--border-secondary);
     color: var(--text-muted);
-    width: var(--button-height-md);
-    height: var(--button-height-md);
-    border-radius: var(--radius-md);
+    width: 20px;
+    height: 20px;
+    border-radius: var(--radius-sm);
     cursor: pointer;
     transition: var(--transition-normal);
     display: flex;
@@ -3178,34 +3186,17 @@ body {
     border-color: var(--border-primary);
 }
 
-/* Scrollable Features Section */
+/* Features Section */
 .features-scrollable-section {
     margin: 0 var(--space-md);
     margin-bottom: var(--space-lg);
-    flex: 1;
-    min-height: 0;
     display: flex;
     flex-direction: column;
 }
 
 .features-scrollable-content {
-    flex: 1;
-    overflow-y: auto;
     padding-right: var(--space-sm);
     padding-bottom: var(--space-sm);
-}
-
-.features-scrollable-content::-webkit-scrollbar {
-    width: var(--scrollbar-width);
-}
-
-.features-scrollable-content::-webkit-scrollbar-track {
-    background: transparent;
-}
-
-.features-scrollable-content::-webkit-scrollbar-thumb {
-    background: var(--scrollbar-thumb);
-    border-radius: var(--space-xs);
 }
 
 /* Quick Add Suggestions Section */
@@ -3214,7 +3205,7 @@ body {
 }
 
 .section-title {
-    font-size: var(--font-size-xl);
+    font-size: var(--font-size-lg);
     font-weight: var(--font-weight-semibold);
     color: var(--text-primary);
     margin: 0 0 var(--space-lg) 0;
@@ -3224,7 +3215,7 @@ body {
 .suggestion-tags {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--space-sm);
+    gap: var(--space-md);
 }
 
 .suggestion-tag {
@@ -3274,7 +3265,7 @@ body {
 
 /* YouTube Features Section */
 .youtube-features-section {
-    margin-bottom: var(--space-sm);
+    margin-bottom: 0;
 }
 
 .feature-toggle-item {
@@ -3292,7 +3283,7 @@ body {
 .feature-info {
     display: flex;
     align-items: center;
-    gap: var(--space-lg);
+    gap: var(--space-md);
     flex: 1;
 }
 
@@ -3302,7 +3293,7 @@ body {
 }
 
 .feature-label {
-    font-size: var(--font-size-lg);
+    font-size: var(--font-size-base);
     font-weight: var(--font-weight-medium);
     color: var(--text-primary);
 }
@@ -3310,8 +3301,8 @@ body {
 /* YouTube Features toggle switches - same styling as existing toggles */
 .youtube-features-section .toggle-switch {
     position: relative;
-    width: var(--toggle-width);
-    height: var(--toggle-height);
+    width: var(--toggle-sm-width);
+    height: var(--toggle-sm-height);
     flex-shrink: 0;
 }
 
@@ -3333,15 +3324,15 @@ body {
     bottom: 0;
     background-color: var(--border-secondary);
     border: 1px solid var(--border-tertiary);
-    border-radius: var(--toggle-height);
+    border-radius: var(--toggle-sm-height);
     transition: var(--transition-normal);
 }
 
 .youtube-features-section .toggle-slider:before {
     position: absolute;
     content: "";
-    height: 18px;
-    width: 18px;
+    height: 14px;
+    width: 14px;
     left: var(--space-xs);
     top: var(--space-xs);
     background-color: #888;
@@ -3355,7 +3346,7 @@ body {
 }
 
 .youtube-features-section .toggle-input:checked + .toggle-slider:before {
-    transform: translateX(20px);
+    transform: translateX(18px);
     background-color: var(--text-primary);
 }
 

--- a/topaz-extension-main/popup/popup.html
+++ b/topaz-extension-main/popup/popup.html
@@ -222,8 +222,6 @@
                             <button class="suggestion-tag" data-tag="shocking">shocking</button>
                             <button class="suggestion-tag" data-tag="gone wrong">gone wrong</button>
                             <button class="suggestion-tag" data-tag="prank">prank</button>
-                            <button class="suggestion-tag" data-tag="conspiracy">conspiracy</button>
-                            <button class="suggestion-tag" data-tag="gossip">gossip</button>
                         </div>
                     </div>
 


### PR DESCRIPTION
- Adjust popup height to 570px for better proportions
- Remove unwanted margins between YouTube features and stats sections
- Optimize stats section spacing with negative margin-top
- Fine-tune simple-mode section height and chips container
- Improve overall visual hierarchy and spacing consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Popup resized to 300×570 with a denser, more compact layout.
  * Smaller typography and tighter spacing across buttons, chips, headers, profiles, and sections.
  * Improved alignment (e.g., centered preview bar) and auto-width tab buttons with consistent padding.
  * Refined colors/contrast and subtle interaction tweaks for hover/active states.

* **Other**
  * Removed two quick-add suggestion buttons: Conspiracy and Gossip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->