### PR TITLE
Revert "Feat/blocked contents tracking"

### DIFF
--- a/topaz-backend-main/main.py
+++ b/topaz-backend-main/main.py
@@ -1885,7 +1885,8 @@ async def fetch_distracting_chunks(analysis_request: GridAnalysisRequest, reques
                         items_found=total_children_to_remove)
             
             return result
-        # If the OpenAI request succeeded, proceed to parse the response
+        else:
+            raise HTTPException(status_code=502, detail="AI service temporarily unavailable")
 
         api_result = response.json()
         response_content = api_result['choices'][0]['message']['content'].strip()

--- a/topaz-extension-main/popup/popup.js
+++ b/topaz-extension-main/popup/popup.js
@@ -673,7 +673,6 @@ async function sendUserDataToBackend(sessionId) {
 
       // Send real blocked items data
       if (realData.blockedItemsData && realData.blockedItemsData.blocked_items.length > 0) {
-        const tC = (await chrome.storage.local.get(['topaz_access_token']))?.topaz_access_token;
         const blockedResponse = await fetch('https://topaz-backend1.onrender.com/api/blocked-items', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
Reverts JohannesGezachew/browserfilter#36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clearer error message when the AI service is temporarily unavailable (returns 502 with a descriptive notice).
- Changes
  - Extension now sends blocked items to the backend without requiring a stored sign-in token.
- Bug Fixes
  - Prevented attempts to parse AI responses when the service is unavailable, reducing confusing failures.
- Chores
  - Streamlined extension data submission by removing unnecessary token retrieval before sending blocked items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->